### PR TITLE
Refactor tox config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,8 @@ matrix:
     - python: 3.7
       env: TOXENV=pep8
     - python: 3.7
-      env: TOXENV=build,tests
+      env: TOXENV=build,py37
     - python: 3.6
-      env: TOXENV=build,tests
+      env: TOXENV=build,py36
     - python: 3.5
-      env: TOXENV=build,tests
+      env: TOXENV=build,py35

--- a/tox.ini
+++ b/tox.ini
@@ -21,33 +21,40 @@ envlist = pep8,build
 [testenv]
 basepython=python3
 usedevelop=True
-envdir = {toxworkdir}/venv
 deps = -r{toxinidir}/requirements.txt
        -r{toxinidir}/test-requirements.txt
+commands = stestr run --slowest {posargs:--black-regex tests.test_style.Test_Style.test_flake8}
 
 passenv =
-    http_proxy
-    https_proxy
-    no_proxy
+    *_proxy
 
 [testenv:pep8]
-commands = flake8 --exclude=build {posargs}
+commands = flake8 {posargs}
 
 [testenv:venv]
+deps = -r{toxinidir}/requirements.txt
+envdir = {toxworkdir}/venv
 commands =
-  windlass {posargs}
+    windlass {posargs}
 
 [testenv:build]
+deps = -r{toxinidir}/requirements.txt
+envdir = {toxworkdir}/venv
 commands =
     windlass --debug \
         --build-only \
         {toxinidir}/products/dev.yml {posargs}
 
-[testenv:tests]
-commands = stestr run --slowest {posargs}
-
-[testenv:windlass]
-commands = windlass {posargs}
-
 [testenv:update-pins]
+envdir = {toxworkdir}/pip_tools
+deps = pip-tools
 commands = pip-compile {posargs:--upgrade --output-file requirements.txt requirements.in}
+
+[testenv:add-pins]
+envdir = {toxworkdir}/pip_tools
+deps = pip-tools
+commands = pip-compile {posargs:--output-file requirements.txt requirements.in}
+
+[flake8]
+show-source = True
+exclude = .venv,.tox,dist,doc,build,*.egg


### PR DESCRIPTION
Adjust the tox configuration to make it easier to test against multiple
versions of python as well as exclude the style tests from the default
as they will be run in CI as a separate job.