### PR TITLE
Various fixes

### DIFF
--- a/tests/test_charts.py
+++ b/tests/test_charts.py
@@ -33,6 +33,9 @@ import windlass.tools
 
 class TestCharts(testtools.TestCase):
 
+    def _yaml_load(self, *args, **kwargs):
+        return yaml.load(*args, Loader=yaml.SafeLoader, **kwargs)
+
     def _build_chart(self):
         """Build the test chart.
 
@@ -48,8 +51,9 @@ class TestCharts(testtools.TestCase):
             },
             working_dir=self.repodir,
             environment=windlass.tools.load_proxy())
-        products = yaml.load(
-            open(os.path.join(self.repodir, 'products/test-chart.yml')))
+        products = self._yaml_load(
+            open(os.path.join(self.repodir, 'products/test-chart.yml')),
+        )
         return windlass.charts.Chart(products['charts'][0])
 
     def setUp(self):
@@ -76,9 +80,9 @@ class TestCharts(testtools.TestCase):
         # Test chart
         stream = open(os.path.join(self.repodir, 'ubuntu-0.0.1.tgz'), 'rb')
         tar = tarfile.open(fileobj=stream, mode='r:gz')
-        chart_data = yaml.load(tar.extractfile('ubuntu/Chart.yaml'))
+        chart_data = self._yaml_load(tar.extractfile('ubuntu/Chart.yaml'))
         self.assertEqual(chart_data['version'], '0.0.1')
-        values_data = yaml.load(tar.extractfile('ubuntu/values.yaml'))
+        values_data = self._yaml_load(tar.extractfile('ubuntu/values.yaml'))
         self.assertEqual(values_data['image']['repository'], 'ubuntu')
         self.assertEqual(values_data['image'].get('registry', None), None)
         self.assertEqual(values_data['image']['tag'], '16.04')
@@ -89,10 +93,10 @@ class TestCharts(testtools.TestCase):
         # Test the output.
         stream = io.BytesIO(data)
         tar = tarfile.open(fileobj=stream, mode='r:gz')
-        chart_data = yaml.load(tar.extractfile('ubuntu/Chart.yaml'))
+        chart_data = self._yaml_load(tar.extractfile('ubuntu/Chart.yaml'))
         self.assertEqual(chart_data['version'], '2.1.0')
 
-        values_data = yaml.load(tar.extractfile('ubuntu/values.yaml'))
+        values_data = self._yaml_load(tar.extractfile('ubuntu/values.yaml'))
         self.assertEqual(values_data['image']['repository'], 'ubuntu')
         self.assertEqual(values_data['image']['registry'], 'reg')
         self.assertEqual(values_data['image']['tag'], '2.1.0')

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -162,7 +162,7 @@ class TestDockerUtils(tests.test_e2e.FakeRegistry):
         )
         self.useFixture(
             fixtures.EnvironmentVariable(
-                'GATHER_BUILDARG_ARGUMENT',
+                'WINDLASS_BUILDARG_ARGUMENT',
                 'somevalue'
             )
         )

--- a/tests/test_pins.py
+++ b/tests/test_pins.py
@@ -30,6 +30,9 @@ import windlass.pins
 
 class TestPins(testtools.TestCase):
 
+    def _yaml_load(self, *args, **kwargs):
+        return yaml.load(*args, Loader=yaml.SafeLoader, **kwargs)
+
     def setUp(self):
         super().setUp()
         self.tempdir = tempfile.TemporaryDirectory()
@@ -64,7 +67,7 @@ class TestPins(testtools.TestCase):
 
         self.assertEqual(updated_files, ['aws/api.yaml'])
 
-        data = self.yaml.load(open(os.path.join(repodir, 'aws/api.yaml')))
+        data = self._yaml_load(open(os.path.join(repodir, 'aws/api.yaml')))
         self.assertEqual(data, {
             'configuration': {'my_app_mac': '0.1',
                               'my_app_win': '0.1',

--- a/windlass/api.py
+++ b/windlass/api.py
@@ -177,7 +177,7 @@ class Artifacts(object):
                 continue
 
             with open(product_file, 'r') as f:
-                product_def = yaml.load(f.read())
+                product_def = yaml.load(f.read(), Loader=yaml.SafeLoader)
 
             # TODO(kerrin) this is not a deep merge, and is pretty poor.
             # Will lose data on you.

--- a/windlass/charts.py
+++ b/windlass/charts.py
@@ -61,7 +61,7 @@ class Chart(windlass.api.Artifact):
     def get_local_version(self):
         chartdir = self.get_chart_dir()
         with open(os.path.join(chartdir, 'Chart.yaml')) as fp:
-            chart = yaml.load(fp)
+            chart = yaml.load(fp, Loader=yaml.SafeLoader)
 
         return chart['version']
 

--- a/windlass/images.py
+++ b/windlass/images.py
@@ -39,7 +39,7 @@ def check_docker_stream(stream):
         if not line:
             continue
 
-        data = yaml.load(line)
+        data = yaml.load(line, Loader=yaml.SafeLoader)
         if 'status' in data:
             if 'id' in data:
                 msg = '%s layer %s: %s' % (name,
@@ -106,7 +106,7 @@ def build_verbosly(name, path, nocache=False, dockerfile=None,
     errors = []
     output = []
     for line in stream:
-        data = yaml.load(line.decode())
+        data = yaml.load(line.decode(), Loader=yaml.SafeLoader)
         if 'stream' in data:
             for out in data['stream'].split('\n\r'):
                 logging.debug('%s: %s', name, out.strip())

--- a/windlass/images.py
+++ b/windlass/images.py
@@ -26,7 +26,7 @@ import windlass.api
 import windlass.exc
 import windlass.tools
 
-BUILDARG_PREFIX = 'GATHER_BUILDARG_'
+BUILDARG_PREFIX = 'WINDLASS_BUILDARG_'
 
 
 def check_docker_stream(stream):

--- a/windlass/pins.py
+++ b/windlass/pins.py
@@ -434,7 +434,10 @@ class OverrideYamlConfiguration(object):
 
             preamble = ''
             try:
-                data = yaml.load(open(full_conf_file))
+                data = ruamel.yaml.load(
+                    open(full_conf_file),
+                    Loader=ruamel.yaml.RoundTripLoader
+                )
             except FileNotFoundError:
                 basedir = os.path.dirname(full_conf_file)
                 os.makedirs(basedir, exist_ok=True)


### PR DESCRIPTION
Specify SafeLoader for yaml loading and update the variable prefix for passing
through arguments to --build-args to remove the remaining reference to the old
project name.