### PR TITLE
Multi registry upload

### DIFF
--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -218,12 +218,12 @@ class TestECRConnectorUsage(TestECRConnectorBase):
                 image_name
 
             )  # noqa
-            # Ensure three tracebacks are there
-            tbs = 0
+            # Ensure three retries are there
+            retry = 0
             for logrecord in cmlogs.records:
-                if 'Traceback' in logrecord.msg:
-                    tbs += 1
-            self.assertEqual(tbs, 3)
+                if 'problem occurred' in logrecord.msg:
+                    retry += 1
+            self.assertEqual(retry, 3)
             self.assertIn('Maximum number of retries occurred (3)', str(e))
 
 

--- a/windlass/registries.py
+++ b/windlass/registries.py
@@ -1,0 +1,106 @@
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+import os
+import re
+
+from windlass import remotes
+
+AWS_ECR_REGEX = r'''
+    (?P<key_id>         # capture the account of the ECR
+        [0-9]{12}
+    )
+    \.dkr\.ecr\.        # string used by ecr currently
+    (?P<region>         # capture the region for the ECR
+        [^\.]+
+    )
+    .amazonaws.com      # domain for all aws services
+'''
+JFROG_REGISTRY_REGEX = r"[^\.]+\.jfrog\.io"
+
+
+def from_url(url, username=None, password=None):
+    """Docker registry factory function
+
+    To assist in auto determining the correct registry config object to
+    use to back a registry config when passed on the command line or
+    provided in a config file without explicit identification, this factory
+    will inspect the url and attempt to make a guess at the correct
+    """
+    if re.match(AWS_ECR_REGEX, url):
+        return EcrDockerRegistry(url, username, password)
+    elif re.match(JFROG_REGISTRY_REGEX, url):
+        return JfrogDockerRegistry(url, username, password)
+    else:
+        return DockerRegistry(url, username, password)
+
+
+class DockerRegistry(object):
+
+    def __init__(self, url, username=None, password=None):
+        self.url = url
+        self.username = username
+        self.password = password
+
+        self.connector = self.get_connector()
+
+    def get_connector(self):
+        # retrieval from the env should move to a config object in future.
+        if self.username is None:
+            self.username = os.environ.get('DOCKER_USER')
+
+        if self.password is None:
+            self.password = os.environ.get('DOCKER_PASSWORD')
+
+        return remotes.DockerConnector(
+            self.url, self.username, self.password
+        )
+
+    def __str__(self):
+        return self.url
+
+
+class EcrDockerRegistry(DockerRegistry):
+
+    def get_connector(self):
+        # support loading auth based on AWS credentials in env
+        if not os.environ.get('AWS_SECRET_ACCESS_KEY'):
+            return super().get_connector()
+
+        # retrieval from the env should move to a config object in future.
+        matcher = re.match(AWS_ECR_REGEX, self.url)
+        key_id = os.environ.get('AWS_ACCESS_KEY_ID') or matcher.group('key_id')
+        secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+        region = os.environ('AWS_DEFAULT_REGION') or matcher.group('region')
+        creds = remotes.AWSCreds(key_id, secret_key, region)
+        return remotes.ECRConnector(creds)
+
+
+class JfrogDockerRegistry(DockerRegistry):
+
+    def get_connector(self):
+        # support loading auth based on ARTIFACTORY creds in env
+
+        # retrieval from the env should move to a config object in future.
+        self.username = os.environ.get('ARTIFACTORY_USER', self.username)
+        self.password = os.environ.get(
+            'ARTIFACTORY_PASSWORD',
+            os.environ.get('ARTIFACTORY_API_KEY', self.password)
+        )
+
+        return remotes.DockerConnector(
+            self.url, self.username, self.password
+        )

--- a/windlass/windlass.py
+++ b/windlass/windlass.py
@@ -15,13 +15,13 @@
 # under the License.
 #
 
-import windlass.api
-import windlass.pins
-
 from argparse import ArgumentParser
 import logging
 import os
 import sys
+
+import windlass.api
+import windlass.pins
 
 
 def process(artifact, ns, **kwargs):
@@ -94,7 +94,7 @@ configuration''')
     download_group.add_argument(
         '--download-docker-registry', action='append',
         default=['registry.hub.docker.com'],
-        help='Registry of images.')
+        help='Registries to search for images.')
     download_group.add_argument(
         '--download-charts-url', action='append', default=[],
         help='Helm repositories.')
@@ -167,9 +167,10 @@ amount of artifacts to process at any one time.''')
     try:
         g.run(
             process,
-            ns=ns,
             artifact_name=ns.artifact_name,
             parallel=not ns.no_parallel,
+            # following args are for the process function
+            ns=ns,
             docker_user=docker_user,
             docker_password=docker_password)
     except windlass.exc.WindlassException:


### PR DESCRIPTION
Upload to multiple registries to allow publishing to multiple endpoints
where some may in turn do additional scanning of the images. Adds
support for retrieving separate authentication details from the
environment for each registry.

Use dedicated objects for docker registries to manage details on
connection and authentication. Migrate code to use this object and
requesting the connector which abstracts the authentication logic.

Due to using the DockerConnector and ECRConnector upload logic, replace
the remote_retry with the standard retry that is used on the images and
ensure that when a max retries exception is thrown that it simply
propagates up the stack instead of getting retried again.