### PR TITLE
 Close file handles to prevent leaks

### DIFF
--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -38,6 +38,7 @@ class DockerImage(fixtures.Fixture):
 
     def _setUp(self):
         self.docker_client = docker.from_env(version='auto')
+        self.addCleanup(self.docker_client.close)
         path = pathlib.Path(__file__).parent.as_posix()
         dockerpath = pathlib.Path(__file__).stem
         self.docker_client.images.build(
@@ -58,14 +59,12 @@ class TestDockerUtils(tests.test_e2e.FakeRegistry):
 
     def cleanUp(self):
         super().cleanUp()
-        client = docker.from_env(
-            version='auto',
-            timeout=180)
-        try:
-            client.api.remove_image(self.random_name)
-        except docker.errors.ImageNotFound:
-            # Image isn't on system so no worries
-            pass
+        with docker.from_env(version='auto', timeout=180) as client:
+            try:
+                client.api.remove_image(self.random_name)
+            except docker.errors.ImageNotFound:
+                # Image isn't on system so no worries
+                pass
 
     def test_failed_image_build(self):
         temp = self.useFixture(
@@ -181,17 +180,18 @@ class TestDockerUtils(tests.test_e2e.FakeRegistry):
             version='auto',
             timeout=180)
 
-        # To capture all output to inspect, must delay removal until
-        # after retrieval of logs otherwise the API can sometimes return
-        # an empty result
-        c = client.containers.create(im)
         try:
+            # To capture all output to inspect, must delay removal until
+            # after retrieval of logs otherwise the API can sometimes return
+            # an empty result
+            c = client.containers.create(im)
             c.start()
             result = c.wait()
             output = c.logs(stdout=True, stderr=True)
         finally:
             c.stop()
             c.remove()
+            client.close()
         # make sure completed successfully
         self.assertEqual(0, result['StatusCode'])
         self.assertEqual('somevalue', output.decode())

--- a/tests/test_pins.py
+++ b/tests/test_pins.py
@@ -67,7 +67,8 @@ class TestPins(testtools.TestCase):
 
         self.assertEqual(updated_files, ['aws/api.yaml'])
 
-        data = self._yaml_load(open(os.path.join(repodir, 'aws/api.yaml')))
+        with open(os.path.join(repodir, 'aws/api.yaml')) as f:
+            data = self._yaml_load(f)
         self.assertEqual(data, {
             'configuration': {'my_app_mac': '0.1',
                               'my_app_win': '0.1',
@@ -206,29 +207,29 @@ pins:
             'region2/example2.yaml',
             'region2/example3.yaml'])
 
-        region1data1 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region1', 'example1.yaml')))
+        with open(os.path.join(self.repodir, 'region1', 'example1.yaml')) as f:
+            region1data1 = yaml.safe_load(f)
         self.assertEqual(
             region1data1['release']['chart'], 'staging-charts/example1:1.0.0')
-        region1data2 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region1', 'example2.yaml')))
+        with open(os.path.join(self.repodir, 'region1', 'example2.yaml')) as f:
+            region1data2 = yaml.safe_load(f)
         self.assertEqual(
             region1data2['release']['chart'], 'example2:1.0.0')
-        region1data3 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region1', 'example3.yaml')))
+        with open(os.path.join(self.repodir, 'region1', 'example3.yaml')) as f:
+            region1data3 = yaml.safe_load(f)
         self.assertEqual(
             region1data3['release']['chart'], 'example3:1.0.0')
 
         # Region2 doesn't know about the helm repository.
-        region2data = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region2', 'example1.yaml')))
-        self.assertEqual(region2data['release']['chart'], 'example1:1.0.0')
-        region2data2 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region2', 'example2.yaml')))
+        with open(os.path.join(self.repodir, 'region2', 'example1.yaml')) as f:
+            region2data1 = yaml.safe_load(f)
+        self.assertEqual(region2data1['release']['chart'], 'example1:1.0.0')
+        with open(os.path.join(self.repodir, 'region2', 'example2.yaml')) as f:
+            region2data2 = yaml.safe_load(f)
         self.assertEqual(
             region2data2['release']['chart'], 'example2:1.0.0')
-        region2data3 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region2', 'example3.yaml')))
+        with open(os.path.join(self.repodir, 'region2', 'example3.yaml')) as f:
+            region2data3 = yaml.safe_load(f)
         self.assertEqual(
             region2data3['release']['chart'], 'example3:1.0.0')
 
@@ -244,8 +245,11 @@ pins:
             })
         self.assertEqual(updated_files, ['image_pins/testing1.yaml'])
 
-        data = yaml.safe_load(
-            open(os.path.join(self.repodir, 'image_pins/testing1.yaml')))
+        with open(
+                os.path.join(self.repodir, 'image_pins', 'testing1.yaml')
+        ) as f:
+            data = yaml.safe_load(f)
+
         self.assertEqual(
             data['images']['some/image'],
             {'version': '1.0.0', 'zing-metadata': {'item': 'value'}})

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -218,12 +218,12 @@ class TestECRConnectorUsage(TestECRConnectorBase):
                 image_name
 
             )  # noqa
-            # Ensure three tracebacks are there
-            tbs = 0
+            # Ensure three retries are there
+            retry = 0
             for logrecord in cmlogs.records:
-                if 'Traceback' in logrecord.msg:
-                    tbs += 1
-            self.assertEqual(tbs, 3)
+                if 'problem occurred' in logrecord.msg:
+                    retry += 1
+            self.assertEqual(retry, 3)
             self.assertIn('Maximum number of retries occurred (3)', str(e))
 
 

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -46,6 +46,7 @@ class TestECRConnectorBase(testtools.TestCase):
         )
         self.stubber = botocore.stub.Stubber(self.ecr_client)
         self.stubber.activate()
+        self.addCleanup(self.stubber.deactivate)
 
         auth_resp = {'authorizationData': [{
             'proxyEndpoint': 'https://%s.dkr.ecr.%s.amazonaws.com' % (

--- a/windlass/generic.py
+++ b/windlass/generic.py
@@ -150,7 +150,8 @@ class Generic(windlass.api.Artifact):
                **kwargs):
 
         local_filename = self.get_filename()
-        data = open(local_filename, 'rb').read()
+        with open(local_filename, 'rb') as fp:
+            data = fp.read()
         if 'remote' in kwargs:
             try:
                 # Ignoring version.
@@ -207,7 +208,8 @@ class Generic(windlass.api.Artifact):
             pass
 
     def export_stream(self, version=None):
-        return open(self.get_filename(), 'rb')
+        with open(self.get_filename(), 'rb') as fp:
+            yield fp
 
     def export(self, export_dir='.', export_name=None, version=None):
         if export_name is None:

--- a/windlass/images.py
+++ b/windlass/images.py
@@ -63,16 +63,23 @@ def check_docker_stream(stream):
 
 
 def push_image(imagename, push_tag='latest', auth_config=None):
+    output = None
     client = docker.from_env(
         version='auto',
         timeout=180)
-    name = multiprocessing.current_process().name
-    logging.info('%s: Pushing as %s:%s', name, imagename, push_tag)
+    try:
+        name = multiprocessing.current_process().name
+        logging.info('%s: Pushing as %s:%s', name, imagename, push_tag)
 
-    output = client.images.push(
-        imagename, push_tag, auth_config=auth_config,
-        stream=True)
-    check_docker_stream(output)
+        output = client.images.push(
+            imagename, push_tag, auth_config=auth_config,
+            stream=True)
+        check_docker_stream(output)
+    finally:
+        if output:
+            output.close()
+        client.close()
+
     return True
 
 
@@ -91,47 +98,51 @@ def build_verbosly(name, path, nocache=False, dockerfile=None,
                    pull=True):
     client = docker.from_env(
         version='auto',
-        timeout=180)
-    bargs = windlass.tools.load_proxy()
-    for envvar in os.environ:
-        if envvar.startswith(BUILDARG_PREFIX):
-            bargs[envvar[len(BUILDARG_PREFIX):]] = os.environ[envvar]
-    logging.info("Building %s from path %s", name, path)
-    stream = client.api.build(path=path,
-                              tag=name,
-                              nocache=nocache,
-                              buildargs=bargs,
-                              dockerfile=dockerfile,
-                              pull=pull)
-    errors = []
-    output = []
-    for line in stream:
-        data = yaml.load(line.decode(), Loader=yaml.SafeLoader)
-        if 'stream' in data:
-            for out in data['stream'].split('\n\r'):
-                logging.debug('%s: %s', name, out.strip())
-                # capture detailed output in case of error
-                output.append(out.strip())
-        elif 'error' in data:
-            errors.append(data['error'])
-    if errors:
-        logging.error(
-            'Failed to build %s. Error details will be shown at the end.',
-            name)
-        debug_data = {'buildargs.%s' % k: v for k, v in bargs.items()}
-        debug_data['dockerfile'] = dockerfile
-        debug_data['tag'] = name
-        debug_data['path'] = path
-        debug_data['nocache'] = str(nocache)
-        debug_data['pull'] = str(pull)
-        raise windlass.exc.WindlassBuildException(
-            "Failed to build {}".format(name),
-            out=output,
-            errors=errors,
-            artifact_name=name,
-            debug_data=debug_data)
-    logging.info("Successfully built %s from path %s", name, path)
-    return client.images.get(name)
+        timeout=180
+    )
+    try:
+        bargs = windlass.tools.load_proxy()
+        for envvar in os.environ:
+            if envvar.startswith(BUILDARG_PREFIX):
+                bargs[envvar[len(BUILDARG_PREFIX):]] = os.environ[envvar]
+        logging.info("Building %s from path %s", name, path)
+        stream = client.api.build(path=path,
+                                  tag=name,
+                                  nocache=nocache,
+                                  buildargs=bargs,
+                                  dockerfile=dockerfile,
+                                  pull=pull)
+        errors = []
+        output = []
+        for line in stream:
+            data = yaml.load(line.decode(), Loader=yaml.SafeLoader)
+            if 'stream' in data:
+                for out in data['stream'].split('\n\r'):
+                    logging.debug('%s: %s', name, out.strip())
+                    # capture detailed output in case of error
+                    output.append(out.strip())
+            elif 'error' in data:
+                errors.append(data['error'])
+        if errors:
+            logging.error(
+                'Failed to build %s. Error details will be shown at the end.',
+                name)
+            debug_data = {'buildargs.%s' % k: v for k, v in bargs.items()}
+            debug_data['dockerfile'] = dockerfile
+            debug_data['tag'] = name
+            debug_data['path'] = path
+            debug_data['nocache'] = str(nocache)
+            debug_data['pull'] = str(pull)
+            raise windlass.exc.WindlassBuildException(
+                "Failed to build {}".format(name),
+                out=output,
+                errors=errors,
+                artifact_name=name,
+                debug_data=debug_data)
+        logging.info("Successfully built %s from path %s", name, path)
+        return client.images.get(name)
+    finally:
+        client.close()
 
 
 def build_image_from_local_repo(repopath, imagepath, name, tags=[],
@@ -189,15 +200,19 @@ class Image(windlass.api.Artifact):
         """
         client = docker.from_env(
             version='auto',
-            timeout=180)
-        logging.info("%s: Pulling image from %s", imagename, remoteimage)
+            timeout=180
+        )
+        try:
+            logging.info("%s: Pulling image from %s", imagename, remoteimage)
 
-        output = client.api.pull(remoteimage, stream=True)
-        check_docker_stream(output)
-        client.api.tag(remoteimage, imagename, tag)
+            output = client.api.pull(remoteimage, stream=True)
+            check_docker_stream(output)
+            client.api.tag(remoteimage, imagename, tag)
 
-        image = client.images.get('%s:%s' % (imagename, tag))
-        return image
+            image = client.images.get('%s:%s' % (imagename, tag))
+            return image
+        finally:
+            client.close()
 
     def url(self, version=None, docker_image_registry=None, **kwargs):
         if version is None:
@@ -241,6 +256,8 @@ class Image(windlass.api.Artifact):
         except docker.errors.ImageNotFound:
             # Image isn't on system so no worries
             pass
+        finally:
+            client.close()
 
     @windlass.api.fall_back('docker_image_registry')
     def delete(self, version=None, docker_image_registry=None, **kwargs):
@@ -248,7 +265,10 @@ class Image(windlass.api.Artifact):
 
         if docker_image_registry:
             self._delete_image(
-                '%s/%s:%s' % (docker_image_registry, self.imagename, tag))
+                '%s/%s:%s' % (
+                    str(docker_image_registry), self.imagename, tag
+                )
+            )
         self._delete_image('%s:%s' % (self.imagename, tag))
 
     @windlass.retry.simple()
@@ -257,30 +277,35 @@ class Image(windlass.api.Artifact):
         client = docker.from_env(
             version='auto',
             timeout=180)
-        if version is None and self.version is None:
-            raise Exception('Must specify version of image to download.')
+        try:
+            if version is None and self.version is None:
+                raise Exception('Must specify version of image to download.')
 
-        if docker_image_registry is None:
-            raise Exception(
-                'docker_image_registry not set for image download. '
-                'Where should we download from?')
+            if docker_image_registry is None:
+                raise Exception(
+                    'docker_image_registry not set for image download. '
+                    'Where should we download from?')
 
-        tag = version or self.version
+            tag = version or self.version
 
-        logging.info('Pinning image: %s to pin: %s' % (self.imagename, tag))
-        remoteimage = '%s/%s:%s' % (docker_image_registry, self.imagename, tag)
+            logging.info('Pinning image: %s to pin: %s', self.imagename, tag)
+            remoteimage = '%s/%s:%s' % (
+                docker_image_registry, self.imagename, tag
+            )
 
-        # Pull the remoteimage down and tag it with the name of artifact
-        # and the requested version
-        self.pull_image(remoteimage, self.imagename, tag)
+            # Pull the remoteimage down and tag it with the name of artifact
+            # and the requested version
+            self.pull_image(remoteimage, self.imagename, tag)
 
-        if tag != self.version:
-            # Tag the image with the version but without the repository
-            client.api.tag(remoteimage, self.imagename, self.version)
+            if tag != self.version:
+                # Tag the image with the version but without the repository
+                client.api.tag(remoteimage, self.imagename, self.version)
 
-        # Apply devtag to this image also. Note that not all artifacts
-        # support a devtag
-        client.api.tag(remoteimage, self.imagename, self.devtag)
+            # Apply devtag to this image also. Note that not all artifacts
+            # support a devtag
+            client.api.tag(remoteimage, self.imagename, self.devtag)
+        finally:
+            client.close()
 
     def update_version(self, version):
         """Tag the image with a new version tag and update internal version.
@@ -290,25 +315,25 @@ class Image(windlass.api.Artifact):
         client = docker.from_env(
             version='auto',
             timeout=180)
-        if version == self.version:
-            logging.debug(
-                "update_version(image): No version change (%s)", version
+        try:
+            if version == self.version:
+                logging.debug(
+                    "update_version(image): No version change (%s)", version
+                )
+                return
+            client.api.tag(
+                '%s:%s' % (self.imagename, self.version),
+                self.imagename, tag=version,
             )
-            return
-        client.api.tag(
-            '%s:%s' % (self.imagename, self.version),
-            self.imagename, tag=version,
-        )
-        return self.set_version(version)
+            return self.set_version(version)
+        finally:
+            client.close()
 
     @windlass.retry.simple()
     @windlass.api.fall_back('docker_image_registry', first_only=True)
     def upload(self, version=None, docker_image_registry=None,
                docker_user=None, docker_password=None,
                **kwargs):
-        client = docker.from_env(
-            version='auto',
-            timeout=180)
         # Start to phase out passing of version to upload.
         if version != self.version:
             logging.debug(
@@ -337,6 +362,7 @@ class Image(windlass.api.Artifact):
         local_fullname = self.url(self.version)
 
         # raises exception if imagename is missing
+        client = docker.from_env(version='auto', timeout=180)
         try:
             client.images.get(local_fullname)
         except docker.errors.ImageNotFound as e:
@@ -345,6 +371,8 @@ class Image(windlass.api.Artifact):
                 artifact_name=self.name,
                 errors=[str(e)]
             )
+        finally:
+            client.close()
 
         # Upload image with this tag
         upload_tag = version or self.version
@@ -360,48 +388,66 @@ class Image(windlass.api.Artifact):
         return result
 
     def export_stream(self, version=None):
-        client = docker.from_env(
-            version='auto',
-            timeout=180)
         img_name = self.imagename + ':' + self.version
-        img = client.images.get(img_name)
-        return img.save()
+
+        client = docker.from_env(version='auto', timeout=180)
+        try:
+            img = client.images.get(img_name)
+            return img.save()
+        finally:
+            client.close()
 
     def export(self, export_dir='.', export_name=None, version=None):
         client = docker.from_env(
             version='auto',
             timeout=180)
-        img_name = self.imagename + ':' + self.version
-        img = client.images.get(img_name)
-        if export_name is None:
-            ver = version or img.short_id[7:]
-            export_name = "%s-%s.tar" % (self.name, ver)
-        export_path = os.path.join(export_dir, export_name)
-        logging.debug("Exporting image %s to %s", img_name, export_path)
+        try:
+            img_name = self.imagename + ':' + self.version
+            img = client.images.get(img_name)
 
-        os.makedirs(os.path.dirname(export_path), exist_ok=True)
-        with open(export_path, 'wb') as f:
-            for chunk in self.export_stream():
-                f.write(chunk)
-        return export_path
+            if export_name is None:
+                ver = version or img.short_id[7:]
+                export_name = "%s-%s.tar" % (self.name, ver)
+            export_path = os.path.join(export_dir, export_name)
+            logging.debug("Exporting image %s to %s", img_name, export_path)
+
+            os.makedirs(os.path.dirname(export_path), exist_ok=True)
+            with open(export_path, 'wb') as f:
+                stream = self.export_stream()
+                try:
+                    for chunk in stream:
+                        f.write(chunk)
+                finally:
+                    stream.close()
+
+            return export_path
+
+        finally:
+            client.close()
 
     def export_signable(self, export_dir='.', export_name=None, version=None):
         """Write the image ID (sha256 hash) to the export file"""
         client = docker.from_env(
             version='auto',
             timeout=180)
-        img_name = self.imagename + ':' + self.version
-        img = client.images.get(img_name)
+        try:
+            img_name = self.imagename + ':' + self.version
+            img = client.images.get(img_name)
 
-        if export_name is None:
-            # img.short_id starts 'sha256:...' - strip the prefix.
-            ver = version or img.short_id[7:]
-            export_name = "%s-%s.id" % (self.imagename, ver)
-        export_path = os.path.join(export_dir, export_name)
-        logging.debug("Exporting image ID for %s to %s", img_name, export_path)
+            if export_name is None:
+                # img.short_id starts 'sha256:...' - strip the prefix.
+                ver = version or img.short_id[7:]
+                export_name = "%s-%s.id" % (self.imagename, ver)
+            export_path = os.path.join(export_dir, export_name)
+            logging.debug(
+                "Exporting image ID for %s to %s", img_name, export_path
+            )
 
-        os.makedirs(os.path.dirname(export_path), exist_ok=True)
-        with open(export_path, 'w') as f:
-            f.write(img.id)
+            os.makedirs(os.path.dirname(export_path), exist_ok=True)
+            with open(export_path, 'w') as f:
+                f.write(img.id)
 
-        return export_path
+            return export_path
+
+        finally:
+            client.close()

--- a/windlass/pins.py
+++ b/windlass/pins.py
@@ -79,11 +79,13 @@ class Pins(object):
             fnlist = [i for i in windlass.tools.all_blob_names(repodir.tree)]
             for pin_files_glob in pin_files_globs:
                 for blob_name in fnmatch.filter(fnlist, pin_files_glob):
-                    yield (repodir.tree / blob_name).data_stream
+                    with (repodir.tree / blob_name).data_stream as stream:
+                        yield stream
         else:
             for pin_files_glob in pin_files_globs:
                 for pin_file in glob.glob(pin_files_glob):
-                    yield open(pin_file)
+                    with open(pin_file) as fp:
+                        yield fp
 
     def iter_artifacts(self, artifacts, artifacttype=None):
         ignore = self.config.get('ignore', [])
@@ -135,8 +137,10 @@ class ImagePins(Pins):
 
         preamble = ''
         try:
-            data = ruamel.yaml.load(
-                open(full_pin_file), Loader=ruamel.yaml.RoundTripLoader)
+            with open(full_pin_file) as fpf:
+                data = ruamel.yaml.load(
+                    fpf, Loader=ruamel.yaml.RoundTripLoader
+                )
         except FileNotFoundError:
             basedir = os.path.dirname(full_pin_file)
             os.makedirs(basedir, exist_ok=True)
@@ -148,7 +152,8 @@ class ImagePins(Pins):
             # write out the contents that are their already, and
             # treat this as a empty data.
             if data is None:
-                preamble = open(full_pin_file).read()
+                with open(full_pin_file) as fpf:
+                    preamble = fpf.read()
                 data = {}
 
         pins = data.get(self.key, {})
@@ -205,6 +210,7 @@ class ImagePins(Pins):
                             windlass.images.Image(dict(
                                 name=image,
                                 version=version)))
+            pin_stream.close()
 
         return pins
 
@@ -230,8 +236,10 @@ class LandscapePins(Pins):
 
             preamble = ''
             try:
-                data = ruamel.yaml.load(
-                    open(full_pin_file), Loader=ruamel.yaml.RoundTripLoader)
+                with open(full_pin_file) as f:
+                    data = ruamel.yaml.load(
+                        f, Loader=ruamel.yaml.RoundTripLoader
+                    )
             except FileNotFoundError:
                 basedir = os.path.dirname(full_pin_file)
                 os.makedirs(basedir, exist_ok=True)
@@ -243,7 +251,8 @@ class LandscapePins(Pins):
                 # write out the contents that are their already, and
                 # treat this as a empty data.
                 if data is None:
-                    preamble = open(full_pin_file).read()
+                    with open(full_pin_file) as f:
+                        preamble = f.read()
                     data = {}
 
             # chartname may contain the name of the helm repository to find
@@ -330,8 +339,10 @@ class GenericPins(Pins):
 
         preamble = ''
         try:
-            data = ruamel.yaml.load(
-                open(full_pin_file), Loader=ruamel.yaml.RoundTripLoader)
+            with open(full_pin_file) as fpf:
+                data = ruamel.yaml.load(
+                    fpf, Loader=ruamel.yaml.RoundTripLoader
+                )
         except FileNotFoundError:
             basedir = os.path.dirname(full_pin_file)
             os.makedirs(basedir, exist_ok=True)
@@ -343,7 +354,8 @@ class GenericPins(Pins):
             # write out the contents that are their already, and
             # treat this as a empty data.
             if data is None:
-                preamble = open(full_pin_file).read()
+                with open(full_pin_file) as fpf:
+                    preamble = fpf.read()
                 data = {}
 
         pins = data.get(self.key, {})
@@ -400,6 +412,7 @@ class GenericPins(Pins):
                             actual_filename=filename,
                         )
                     )
+            pin_stream.close()
         return pins
 
 
@@ -434,10 +447,10 @@ class OverrideYamlConfiguration(object):
 
             preamble = ''
             try:
-                data = ruamel.yaml.load(
-                    open(full_conf_file),
-                    Loader=ruamel.yaml.RoundTripLoader
-                )
+                with open(full_conf_file) as fp:
+                    data = ruamel.yaml.load(
+                        fp, Loader=ruamel.yaml.RoundTripLoader
+                    )
             except FileNotFoundError:
                 basedir = os.path.dirname(full_conf_file)
                 os.makedirs(basedir, exist_ok=True)
@@ -449,7 +462,8 @@ class OverrideYamlConfiguration(object):
                 # write out the contents that are their already, and
                 # treat this as a empty data.
                 if data is None:
-                    preamble = open(full_conf_file).read()
+                    with open(full_conf_file) as fp:
+                        preamble = fp.read()
                     data = {}
 
             updatedfile = False
@@ -568,8 +582,11 @@ def read_configuration(repodir=None):
             if not os.path.exists(configuration):
                 return {}
         stream = open(configuration)
-    configuration_data = ruamel.yaml.load(
-        stream, Loader=ruamel.yaml.RoundTripLoader)
+    try:
+        configuration_data = ruamel.yaml.load(
+            stream, Loader=ruamel.yaml.RoundTripLoader)
+    finally:
+        stream.close()
 
     return configuration_data
 

--- a/windlass/registries.py
+++ b/windlass/registries.py
@@ -1,0 +1,106 @@
+#
+# (c) Copyright 2019 Hewlett Packard Enterprise Development LP
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+
+import os
+import re
+
+from windlass import remotes
+
+AWS_ECR_REGEX = r'''
+    (?P<key_id>         # capture the account of the ECR
+        [0-9]{12}
+    )
+    \.dkr\.ecr\.        # string used by ecr currently
+    (?P<region>         # capture the region for the ECR
+        [^\.]+
+    )
+    .amazonaws.com      # domain for all aws services
+'''
+JFROG_REGISTRY_REGEX = r"[^\.]+\.jfrog\.io"
+
+
+def from_url(url, username=None, password=None):
+    """Docker registry factory function
+
+    To assist in auto determining the correct registry config object to
+    use to back a registry config when passed on the command line or
+    provided in a config file without explicit identification, this factory
+    will inspect the url and attempt to make a guess at the correct
+    """
+    if re.match(AWS_ECR_REGEX, url):
+        return EcrDockerRegistry(url, username, password)
+    elif re.match(JFROG_REGISTRY_REGEX, url):
+        return JfrogDockerRegistry(url, username, password)
+    else:
+        return DockerRegistry(url, username, password)
+
+
+class DockerRegistry(object):
+
+    def __init__(self, url, username=None, password=None):
+        self.url = url
+        self.username = username
+        self.password = password
+
+        self.connector = self.get_connector()
+
+    def get_connector(self):
+        # retrieval from the env should move to a config object in future.
+        if self.username is None:
+            self.username = os.environ.get('DOCKER_USER')
+
+        if self.password is None:
+            self.password = os.environ.get('DOCKER_PASSWORD')
+
+        return remotes.DockerConnector(
+            self.url, self.username, self.password
+        )
+
+    def __str__(self):
+        return self.url
+
+
+class EcrDockerRegistry(DockerRegistry):
+
+    def get_connector(self):
+        # support loading auth based on AWS credentials in env
+        if not os.environ.get('AWS_SECRET_ACCESS_KEY'):
+            return super().get_connector()
+
+        # retrieval from the env should move to a config object in future.
+        matcher = re.match(AWS_ECR_REGEX, self.url)
+        key_id = os.environ.get('AWS_ACCESS_KEY_ID') or matcher.group('key_id')
+        secret_key = os.environ.get('AWS_SECRET_ACCESS_KEY')
+        region = os.environ('AWS_DEFAULT_REGION') or matcher.group('region')
+        creds = remotes.AWSCreds(key_id, secret_key, region)
+        return remotes.ECRConnector(creds)
+
+
+class JfrogDockerRegistry(DockerRegistry):
+
+    def get_connector(self):
+        # support loading auth based on ARTIFACTORY creds in env
+
+        # retrieval from the env should move to a config object in future.
+        self.username = os.environ.get('ARTIFACTORY_USER', self.username)
+        self.password = os.environ.get(
+            'ARTIFACTORY_PASSWORD',
+            os.environ.get('ARTIFACTORY_API_KEY', self.password)
+        )
+
+        return remotes.DockerConnector(
+            self.url, self.username, self.password
+        )

--- a/windlass/windlass.py
+++ b/windlass/windlass.py
@@ -15,13 +15,13 @@
 # under the License.
 #
 
-import windlass.api
-import windlass.pins
-
 from argparse import ArgumentParser
 import logging
 import os
 import sys
+
+import windlass.api
+import windlass.pins
 
 
 def process(artifact, ns, **kwargs):
@@ -94,7 +94,7 @@ configuration''')
     download_group.add_argument(
         '--download-docker-registry', action='append',
         default=['registry.hub.docker.com'],
-        help='Registry of images.')
+        help='Registries to search for images.')
     download_group.add_argument(
         '--download-charts-url', action='append', default=[],
         help='Helm repositories.')
@@ -167,9 +167,10 @@ amount of artifacts to process at any one time.''')
     try:
         g.run(
             process,
-            ns=ns,
             artifact_name=ns.artifact_name,
             parallel=not ns.no_parallel,
+            # following args are for the process function
+            ns=ns,
             docker_user=docker_user,
             docker_password=docker_password)
     except windlass.exc.WindlassException:


### PR DESCRIPTION
Testing within PyCharms exposed leaking of references to sockets and
file handles that should be closed either explicitly or implicitly.

Make sure to use context managers where possible to ensure explicit
closing of file handles and otherwise use of try/finally where needed
to ensure handles are closed once no longer needed.

This will help python clean up correctly.