### PR TITLE
Close file handles to prevent leaks

### DIFF
--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -179,19 +179,19 @@ class TestDockerUtils(tests.test_e2e.FakeRegistry):
         client = docker.from_env(
             version='auto',
             timeout=180)
+        self.addCleanup(client.close)
 
+        # To capture all output to inspect, must delay removal until
+        # after retrieval of logs otherwise the API can sometimes return
+        # an empty result
+        c = client.containers.create(im)
         try:
-            # To capture all output to inspect, must delay removal until
-            # after retrieval of logs otherwise the API can sometimes return
-            # an empty result
-            c = client.containers.create(im)
             c.start()
             result = c.wait()
             output = c.logs(stdout=True, stderr=True)
         finally:
             c.stop()
             c.remove()
-            client.close()
         # make sure completed successfully
         self.assertEqual(0, result['StatusCode'])
         self.assertEqual('somevalue', output.decode())

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -38,6 +38,7 @@ class DockerImage(fixtures.Fixture):
 
     def _setUp(self):
         self.docker_client = docker.from_env(version='auto')
+        self.addCleanup(self.docker_client.close)
         path = pathlib.Path(__file__).parent.as_posix()
         dockerpath = pathlib.Path(__file__).stem
         self.docker_client.images.build(
@@ -58,14 +59,12 @@ class TestDockerUtils(tests.test_e2e.FakeRegistry):
 
     def cleanUp(self):
         super().cleanUp()
-        client = docker.from_env(
-            version='auto',
-            timeout=180)
-        try:
-            client.api.remove_image(self.random_name)
-        except docker.errors.ImageNotFound:
-            # Image isn't on system so no worries
-            pass
+        with docker.from_env(version='auto', timeout=180) as client:
+            try:
+                client.api.remove_image(self.random_name)
+            except docker.errors.ImageNotFound:
+                # Image isn't on system so no worries
+                pass
 
     def test_failed_image_build(self):
         temp = self.useFixture(
@@ -181,17 +180,18 @@ class TestDockerUtils(tests.test_e2e.FakeRegistry):
             version='auto',
             timeout=180)
 
-        # To capture all output to inspect, must delay removal until
-        # after retrieval of logs otherwise the API can sometimes return
-        # an empty result
-        c = client.containers.create(im)
         try:
+            # To capture all output to inspect, must delay removal until
+            # after retrieval of logs otherwise the API can sometimes return
+            # an empty result
+            c = client.containers.create(im)
             c.start()
             result = c.wait()
             output = c.logs(stdout=True, stderr=True)
         finally:
             c.stop()
             c.remove()
+            client.close()
         # make sure completed successfully
         self.assertEqual(0, result['StatusCode'])
         self.assertEqual('somevalue', output.decode())

--- a/tests/test_pins.py
+++ b/tests/test_pins.py
@@ -67,7 +67,8 @@ class TestPins(testtools.TestCase):
 
         self.assertEqual(updated_files, ['aws/api.yaml'])
 
-        data = self._yaml_load(open(os.path.join(repodir, 'aws/api.yaml')))
+        with open(os.path.join(repodir, 'aws/api.yaml')) as f:
+            data = self._yaml_load(f)
         self.assertEqual(data, {
             'configuration': {'my_app_mac': '0.1',
                               'my_app_win': '0.1',
@@ -206,29 +207,29 @@ pins:
             'region2/example2.yaml',
             'region2/example3.yaml'])
 
-        region1data1 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region1', 'example1.yaml')))
+        with open(os.path.join(self.repodir, 'region1', 'example1.yaml')) as f:
+            region1data1 = yaml.safe_load(f)
         self.assertEqual(
             region1data1['release']['chart'], 'staging-charts/example1:1.0.0')
-        region1data2 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region1', 'example2.yaml')))
+        with open(os.path.join(self.repodir, 'region1', 'example2.yaml')) as f:
+            region1data2 = yaml.safe_load(f)
         self.assertEqual(
             region1data2['release']['chart'], 'example2:1.0.0')
-        region1data3 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region1', 'example3.yaml')))
+        with open(os.path.join(self.repodir, 'region1', 'example3.yaml')) as f:
+            region1data3 = yaml.safe_load(f)
         self.assertEqual(
             region1data3['release']['chart'], 'example3:1.0.0')
 
         # Region2 doesn't know about the helm repository.
-        region2data = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region2', 'example1.yaml')))
-        self.assertEqual(region2data['release']['chart'], 'example1:1.0.0')
-        region2data2 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region2', 'example2.yaml')))
+        with open(os.path.join(self.repodir, 'region2', 'example1.yaml')) as f:
+            region2data1 = yaml.safe_load(f)
+        self.assertEqual(region2data1['release']['chart'], 'example1:1.0.0')
+        with open(os.path.join(self.repodir, 'region2', 'example2.yaml')) as f:
+            region2data2 = yaml.safe_load(f)
         self.assertEqual(
             region2data2['release']['chart'], 'example2:1.0.0')
-        region2data3 = yaml.safe_load(
-            open(os.path.join(self.repodir, 'region2', 'example3.yaml')))
+        with open(os.path.join(self.repodir, 'region2', 'example3.yaml')) as f:
+            region2data3 = yaml.safe_load(f)
         self.assertEqual(
             region2data3['release']['chart'], 'example3:1.0.0')
 
@@ -244,8 +245,11 @@ pins:
             })
         self.assertEqual(updated_files, ['image_pins/testing1.yaml'])
 
-        data = yaml.safe_load(
-            open(os.path.join(self.repodir, 'image_pins/testing1.yaml')))
+        with open(
+                os.path.join(self.repodir, 'image_pins', 'testing1.yaml')
+        ) as f:
+            data = yaml.safe_load(f)
+
         self.assertEqual(
             data['images']['some/image'],
             {'version': '1.0.0', 'zing-metadata': {'item': 'value'}})

--- a/tests/test_remotes.py
+++ b/tests/test_remotes.py
@@ -46,6 +46,7 @@ class TestECRConnectorBase(testtools.TestCase):
         )
         self.stubber = botocore.stub.Stubber(self.ecr_client)
         self.stubber.activate()
+        self.addCleanup(self.stubber.deactivate)
 
         auth_resp = {'authorizationData': [{
             'proxyEndpoint': 'https://%s.dkr.ecr.%s.amazonaws.com' % (

--- a/windlass/generic.py
+++ b/windlass/generic.py
@@ -150,7 +150,8 @@ class Generic(windlass.api.Artifact):
                **kwargs):
 
         local_filename = self.get_filename()
-        data = open(local_filename, 'rb').read()
+        with open(local_filename, 'rb') as fp:
+            data = fp.read()
         if 'remote' in kwargs:
             try:
                 # Ignoring version.
@@ -207,7 +208,8 @@ class Generic(windlass.api.Artifact):
             pass
 
     def export_stream(self, version=None):
-        return open(self.get_filename(), 'rb')
+        with open(self.get_filename(), 'rb') as fp:
+            yield fp
 
     def export(self, export_dir='.', export_name=None, version=None):
         if export_name is None:

--- a/windlass/pins.py
+++ b/windlass/pins.py
@@ -210,7 +210,6 @@ class ImagePins(Pins):
                             windlass.images.Image(dict(
                                 name=image,
                                 version=version)))
-            pin_stream.close()
 
         return pins
 

--- a/windlass/pins.py
+++ b/windlass/pins.py
@@ -79,11 +79,13 @@ class Pins(object):
             fnlist = [i for i in windlass.tools.all_blob_names(repodir.tree)]
             for pin_files_glob in pin_files_globs:
                 for blob_name in fnmatch.filter(fnlist, pin_files_glob):
-                    yield (repodir.tree / blob_name).data_stream
+                    with (repodir.tree / blob_name).data_stream as stream:
+                        yield stream
         else:
             for pin_files_glob in pin_files_globs:
                 for pin_file in glob.glob(pin_files_glob):
-                    yield open(pin_file)
+                    with open(pin_file) as fp:
+                        yield fp
 
     def iter_artifacts(self, artifacts, artifacttype=None):
         ignore = self.config.get('ignore', [])
@@ -135,8 +137,10 @@ class ImagePins(Pins):
 
         preamble = ''
         try:
-            data = ruamel.yaml.load(
-                open(full_pin_file), Loader=ruamel.yaml.RoundTripLoader)
+            with open(full_pin_file) as fpf:
+                data = ruamel.yaml.load(
+                    fpf, Loader=ruamel.yaml.RoundTripLoader
+                )
         except FileNotFoundError:
             basedir = os.path.dirname(full_pin_file)
             os.makedirs(basedir, exist_ok=True)
@@ -148,7 +152,8 @@ class ImagePins(Pins):
             # write out the contents that are their already, and
             # treat this as a empty data.
             if data is None:
-                preamble = open(full_pin_file).read()
+                with open(full_pin_file) as fpf:
+                    preamble = fpf.read()
                 data = {}
 
         pins = data.get(self.key, {})
@@ -205,6 +210,7 @@ class ImagePins(Pins):
                             windlass.images.Image(dict(
                                 name=image,
                                 version=version)))
+            pin_stream.close()
 
         return pins
 
@@ -230,8 +236,10 @@ class LandscapePins(Pins):
 
             preamble = ''
             try:
-                data = ruamel.yaml.load(
-                    open(full_pin_file), Loader=ruamel.yaml.RoundTripLoader)
+                with open(full_pin_file) as f:
+                    data = ruamel.yaml.load(
+                        f, Loader=ruamel.yaml.RoundTripLoader
+                    )
             except FileNotFoundError:
                 basedir = os.path.dirname(full_pin_file)
                 os.makedirs(basedir, exist_ok=True)
@@ -243,7 +251,8 @@ class LandscapePins(Pins):
                 # write out the contents that are their already, and
                 # treat this as a empty data.
                 if data is None:
-                    preamble = open(full_pin_file).read()
+                    with open(full_pin_file) as f:
+                        preamble = f.read()
                     data = {}
 
             # chartname may contain the name of the helm repository to find
@@ -330,8 +339,10 @@ class GenericPins(Pins):
 
         preamble = ''
         try:
-            data = ruamel.yaml.load(
-                open(full_pin_file), Loader=ruamel.yaml.RoundTripLoader)
+            with open(full_pin_file) as fpf:
+                data = ruamel.yaml.load(
+                    fpf, Loader=ruamel.yaml.RoundTripLoader
+                )
         except FileNotFoundError:
             basedir = os.path.dirname(full_pin_file)
             os.makedirs(basedir, exist_ok=True)
@@ -343,7 +354,8 @@ class GenericPins(Pins):
             # write out the contents that are their already, and
             # treat this as a empty data.
             if data is None:
-                preamble = open(full_pin_file).read()
+                with open(full_pin_file) as fpf:
+                    preamble = fpf.read()
                 data = {}
 
         pins = data.get(self.key, {})
@@ -400,6 +412,7 @@ class GenericPins(Pins):
                             actual_filename=filename,
                         )
                     )
+            pin_stream.close()
         return pins
 
 
@@ -434,10 +447,10 @@ class OverrideYamlConfiguration(object):
 
             preamble = ''
             try:
-                data = ruamel.yaml.load(
-                    open(full_conf_file),
-                    Loader=ruamel.yaml.RoundTripLoader
-                )
+                with open(full_conf_file) as fp:
+                    data = ruamel.yaml.load(
+                        fp, Loader=ruamel.yaml.RoundTripLoader
+                    )
             except FileNotFoundError:
                 basedir = os.path.dirname(full_conf_file)
                 os.makedirs(basedir, exist_ok=True)
@@ -449,7 +462,8 @@ class OverrideYamlConfiguration(object):
                 # write out the contents that are their already, and
                 # treat this as a empty data.
                 if data is None:
-                    preamble = open(full_conf_file).read()
+                    with open(full_conf_file) as fp:
+                        preamble = fp.read()
                     data = {}
 
             updatedfile = False
@@ -568,8 +582,11 @@ def read_configuration(repodir=None):
             if not os.path.exists(configuration):
                 return {}
         stream = open(configuration)
-    configuration_data = ruamel.yaml.load(
-        stream, Loader=ruamel.yaml.RoundTripLoader)
+    try:
+        configuration_data = ruamel.yaml.load(
+            stream, Loader=ruamel.yaml.RoundTripLoader)
+    finally:
+        stream.close()
 
     return configuration_data
 


### PR DESCRIPTION
Testing within PyCharms exposed leaking of references to sockets and
file handles that should be closed either explicitly or implicitly.

Make sure to use context managers where possible to ensure explicit
closing of file handles and otherwise use of try/finally where needed
to ensure handles are closed once no longer needed.