### PR TITLE
CircleCI now uses a socket for remote docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,9 +82,7 @@ jobs:
           name: Build self using built image
           command: |
             docker create \
-                -e DOCKER_CERT_PATH \
                 -e DOCKER_HOST \
-                -e DOCKER_TLS_VERIFY \
                 -e NO_PROXY \
                 -v /src \
                 -w /src \
@@ -95,7 +93,6 @@ jobs:
 
             # specifying the workspace directory doesn't work
             docker cp . windlass:/src
-            docker cp ${DOCKER_CERT_PATH} windlass:${DOCKER_CERT_PATH}
 
             docker start -a windlass
       - persist_to_workspace:
@@ -127,9 +124,7 @@ jobs:
             CIRCLE_TAG="${CIRCLE_TAG/v/}"
             BUILD_TAG="${CIRCLE_TAG:-${BUILD_VERSION:-${CIRCLE_BRANCH}}}"
             docker create \
-                -e DOCKER_CERT_PATH \
                 -e DOCKER_HOST \
-                -e DOCKER_TLS_VERIFY \
                 -e NO_PROXY \
                 -e DOCKER_USER=${QUAY_USER} \
                 -e DOCKER_TOKEN=${QUAY_TOKEN} \
@@ -144,7 +139,6 @@ jobs:
 
             # specifying the workspace directory doesn't work
             docker cp . windlass:/src
-            docker cp ${DOCKER_CERT_PATH} windlass:${DOCKER_CERT_PATH}
 
             docker start -a windlass
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,9 @@ jobs:
           command: |
             docker create \
                 -e DOCKER_HOST \
+                -e DOCKER_MACHINE_NAME \
                 -e NO_PROXY \
+                -v /var/run/docker.sock \
                 -v /src \
                 -w /src \
                 --name windlass \
@@ -125,9 +127,11 @@ jobs:
             BUILD_TAG="${CIRCLE_TAG:-${BUILD_VERSION:-${CIRCLE_BRANCH}}}"
             docker create \
                 -e DOCKER_HOST \
+                -e DOCKER_MACHINE_NAME \
                 -e NO_PROXY \
                 -e DOCKER_USER=${QUAY_USER} \
                 -e DOCKER_TOKEN=${QUAY_TOKEN} \
+                -v /var/run/docker.sock \
                 -v /src \
                 -w /src \
                 --name windlass \


### PR DESCRIPTION
Drop variables previously needed when CircleCI would connect to a remote
docker instance.
